### PR TITLE
patches (#582)

### DIFF
--- a/selfdrive/debug/dump.py
+++ b/selfdrive/debug/dump.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
       port = int(m)
     else:
       print("service not found")
-      exit(-1)
+      sys.exit(-1)
     sock = messaging.sub_sock(context, port, poller, addr=args.addr)
     if args.proxy:
       republish_socks[sock] = messaging.pub_sock(context, port)

--- a/selfdrive/tombstoned.py
+++ b/selfdrive/tombstoned.py
@@ -11,8 +11,9 @@ from selfdrive.version import version, dirty
 from selfdrive.swaglog import cloudlog
 
 def get_tombstones():
-  return [("/data/tombstones/"+fn, int(os.stat("/data/tombstones/"+fn).st_ctime) )
-          for fn in os.listdir("/data/tombstones") if fn.startswith("tombstone")]
+  DIR_DATA = "/data/tombstones/"
+  return [(DIR_DATA + fn, int(os.stat(DIR_DATA + fn).st_ctime) )
+          for fn in os.listdir(DIR_DATA) if fn.startswith("tombstone")]
 
 def report_tombstone(fn, client):
   mtime = os.path.getmtime(fn)


### PR DESCRIPTION
* selfdrive: add sys module to exit call

exit() is a helper for interactive shell. Let's explicit
use the module sys.

* selfdrive: tomstoned.py use constant for /data/tombstones/

Instead of use multiple times a string for
the data dir, use a variable.