### PR TITLE
Cherokee KL - PID Lateral Tested, Reduced MinSteer Tested

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -86,7 +86,7 @@ function launch {
   if [ ! -f $DIR/prebuilt ]; then
     ./build.py
   fi
-  ./manager.py
+  ./manager.py > /tmp/log-$(date -Iseconds)
 
   # if broken, keep on screen error
   while true; do sleep 1; done

--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -51,7 +51,7 @@ class CarController:
       # TODO: can we make this more sane? why is it different for all the cars?
       lkas_control_bit = self.lkas_control_bit_prev
       if CS.out.vEgo > self.CP.minSteerSpeed:
-        lkas_control_bit = True
+        lkas_control_bit = CC.enabled
       elif self.CP.flags & ChryslerFlags.HIGHER_MIN_STEERING_SPEED:
         if CS.out.vEgo < (self.CP.minSteerSpeed - 3.0):
           lkas_control_bit = False
@@ -62,7 +62,7 @@ class CarController:
         # TODO: Chrysler 200 appears to support asymmetric down to mid-13s, Cherokee not verified yet, model-year variances likely
         # TODO: Consolidate with HIGHER_MIN_STEERING_SPEED cars if we can make engage consistently work at 17.5 m/s
         if CS.out.vEgo < 16.5:
-          lkas_control_bit = False
+          lkas_control_bit = CC.enabled
 
       # EPS faults if LKAS re-enables too quickly
       lkas_control_bit = lkas_control_bit and (self.frame - self.last_lkas_falling_edge > 200)

--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -49,9 +49,9 @@ class CarController:
     if self.frame % self.params.STEER_STEP == 0:
 
       # TODO: can we make this more sane? why is it different for all the cars?
-      lkas_control_bit = CC.enabled
+      lkas_control_bit = self.lkas_control_bit_prev
       if CS.out.vEgo > self.CP.minSteerSpeed:
-        lkas_control_bit = False
+        lkas_control_bit = True
       elif self.CP.flags & ChryslerFlags.HIGHER_MIN_STEERING_SPEED:
         if CS.out.vEgo < (self.CP.minSteerSpeed - 3.0):
           lkas_control_bit = False
@@ -62,7 +62,7 @@ class CarController:
         # TODO: Chrysler 200 appears to support asymmetric down to mid-13s, Cherokee not verified yet, model-year variances likely
         # TODO: Consolidate with HIGHER_MIN_STEERING_SPEED cars if we can make engage consistently work at 17.5 m/s
         if CS.out.vEgo < 16.5:
-          lkas_control_bit = True
+          lkas_control_bit = False
 
       # EPS faults if LKAS re-enables too quickly
       lkas_control_bit = lkas_control_bit and (self.frame - self.last_lkas_falling_edge > 200)

--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -62,7 +62,7 @@ class CarController:
         # TODO: Chrysler 200 appears to support asymmetric down to mid-13s, Cherokee not verified yet, model-year variances likely
         # TODO: Consolidate with HIGHER_MIN_STEERING_SPEED cars if we can make engage consistently work at 17.5 m/s
         if CS.out.vEgo < 16.5:
-          lkas_control_bit = False
+          lkas_control_bit = True
 
       # EPS faults if LKAS re-enables too quickly
       lkas_control_bit = lkas_control_bit and (self.frame - self.last_lkas_falling_edge > 200)

--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -51,7 +51,7 @@ class CarController:
       # TODO: can we make this more sane? why is it different for all the cars?
       lkas_control_bit = self.lkas_control_bit_prev
       if CS.out.vEgo > self.CP.minSteerSpeed:
-        lkas_control_bit = CC.enabled
+        lkas_control_bit = True
       elif self.CP.flags & ChryslerFlags.HIGHER_MIN_STEERING_SPEED:
         if CS.out.vEgo < (self.CP.minSteerSpeed - 3.0):
           lkas_control_bit = False
@@ -62,7 +62,7 @@ class CarController:
         # TODO: Chrysler 200 appears to support asymmetric down to mid-13s, Cherokee not verified yet, model-year variances likely
         # TODO: Consolidate with HIGHER_MIN_STEERING_SPEED cars if we can make engage consistently work at 17.5 m/s
         if CS.out.vEgo < 16.5:
-          lkas_control_bit = CC.enabled
+          lkas_control_bit = False
 
       # EPS faults if LKAS re-enables too quickly
       lkas_control_bit = lkas_control_bit and (self.frame - self.last_lkas_falling_edge > 200)

--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -51,7 +51,7 @@ class CarController:
       # TODO: can we make this more sane? why is it different for all the cars?
       lkas_control_bit = self.lkas_control_bit_prev
       if CS.out.vEgo > self.CP.minSteerSpeed:
-        lkas_control_bit = True
+        lkas_control_bit = False
       elif self.CP.flags & ChryslerFlags.HIGHER_MIN_STEERING_SPEED:
         if CS.out.vEgo < (self.CP.minSteerSpeed - 3.0):
           lkas_control_bit = False

--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -49,7 +49,7 @@ class CarController:
     if self.frame % self.params.STEER_STEP == 0:
 
       # TODO: can we make this more sane? why is it different for all the cars?
-      lkas_control_bit = self.lkas_control_bit_prev
+      lkas_control_bit = CC.enabled
       if CS.out.vEgo > self.CP.minSteerSpeed:
         lkas_control_bit = False
       elif self.CP.flags & ChryslerFlags.HIGHER_MIN_STEERING_SPEED:

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -53,7 +53,7 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 1747
       ret.wheelbase = 2.70
       ret.steerRatio = 17  # TODO: verify against params learner
-      ret.minSteerSpeed = 17.5  # 19' CHerokee KL Tested, Works
+      ret.minSteerSpeed = 0  # 19' CHerokee KL Tested, Works// testing wp
       ret.steerActuatorDelay = 0.2
       #19' Cherokee KL Tested, Works - Enabling PID-based lateral tuning
             #Disable with intent to enable Lateral PID Tuning with same parameters as other Chryslers

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -53,14 +53,14 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 1747
       ret.wheelbase = 2.70
       ret.steerRatio = 17  # TODO: verify against params learner
-      ret.minSteerSpeed = 18.5  # 19' CHerokee KL Tested, Works// testing wp
-      ret.steerActuatorDelay = 0.2
+      ret.minSteerSpeed = 18.5  # 19' Cherokee KL Tested, Works
+      ret.steerActuatorDelay = 0.15 # Down from 0.2, 19' Cherokee KL Tested, Works well 
       #19' Cherokee KL Tested, Works - Enabling PID-based lateral tuning
             #Disable with intent to enable Lateral PID Tuning with same parameters as other Chryslers
       ret.lateralTuning.init('pid')
       ret.lateralTuning.pid.kpBP, ret.lateralTuning.pid.kiBP = [[9., 20.], [9., 20.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.15, 0.30], [0.03, 0.05]]
-      ret.lateralTuning.pid.kf = 0.00007 #Up from 0.00006 - Testing 
+      ret.lateralTuning.pid.kf = 0.0002 #Up from 0.00006, 19' Cherokee KL Tested, Works well 
       #CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning, 1.0, False)
 
     elif candidate in (CAR.JEEP_GRAND_CHEROKEE, CAR.JEEP_GRAND_CHEROKEE_2019):

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -53,7 +53,7 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 1747
       ret.wheelbase = 2.70
       ret.steerRatio = 17  # TODO: verify against params learner
-      ret.minSteerSpeed = 0  # 19' CHerokee KL Tested, Works// testing wp
+      ret.minSteerSpeed = 18.5  # 19' CHerokee KL Tested, Works// testing wp
       ret.steerActuatorDelay = 0.2
       #19' Cherokee KL Tested, Works - Enabling PID-based lateral tuning
             #Disable with intent to enable Lateral PID Tuning with same parameters as other Chryslers

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -53,9 +53,15 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 1747
       ret.wheelbase = 2.70
       ret.steerRatio = 17  # TODO: verify against params learner
-      ret.minSteerSpeed = 18.5  # TODO: conservative, need to test
+      ret.minSteerSpeed = 17.5  # 19' CHerokee KL Tested, Works
       ret.steerActuatorDelay = 0.2
-      CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning, 1.0, False)
+      #19' Cherokee KL Tested, Works - Enabling PID-based lateral tuning
+            #Disable with intent to enable Lateral PID Tuning with same parameters as other Chryslers
+      ret.lateralTuning.init('pid')
+      ret.lateralTuning.pid.kpBP, ret.lateralTuning.pid.kiBP = [[9., 20.], [9., 20.]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.15, 0.30], [0.03, 0.05]]
+      ret.lateralTuning.pid.kf = 0.00007 #Up from 0.00006 - Testing 
+      #CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning, 1.0, False)
 
     elif candidate in (CAR.JEEP_GRAND_CHEROKEE, CAR.JEEP_GRAND_CHEROKEE_2019):
       ret.mass = 1778

--- a/selfdrive/car/chrysler/values.py
+++ b/selfdrive/car/chrysler/values.py
@@ -12,7 +12,7 @@ Ecu = car.CarParams.Ecu
 
 
 class ChryslerFlags(IntFlag):
-  HIGHER_MIN_STEERING_SPEED = 1
+  HIGHER_MIN_STEERING_SPEED = 0 #Disabling for 19' Cherokee Kl testing.   Spent some time testing asymmetic speed settings, was not productive.
 
 
 class CAR(StrEnum):

--- a/selfdrive/car/chrysler/values.py
+++ b/selfdrive/car/chrysler/values.py
@@ -54,7 +54,7 @@ class CarControllerParams:
     elif CP.carFingerprint in CUSW_CARS:
       self.STEER_DELTA_UP = 4
       self.STEER_DELTA_DOWN = 4
-      self.STEER_MAX = 261  # TODO: re-validate this, Panda is at 261
+      self.STEER_MAX = 250  # TODO: re-validate this, Panda is at 261, 19 Cherokee KL faults at 261.  eps or panda?
     else:
       self.STEER_DELTA_UP = 3
       self.STEER_DELTA_DOWN = 3

--- a/selfdrive/car/chrysler/values.py
+++ b/selfdrive/car/chrysler/values.py
@@ -54,7 +54,7 @@ class CarControllerParams:
     elif CP.carFingerprint in CUSW_CARS:
       self.STEER_DELTA_UP = 4
       self.STEER_DELTA_DOWN = 4
-      self.STEER_MAX = 250  # TODO: re-validate this, Panda is at 261
+      self.STEER_MAX = 261  # TODO: re-validate this, Panda is at 261
     else:
       self.STEER_DELTA_UP = 3
       self.STEER_DELTA_DOWN = 3


### PR DESCRIPTION
Miles544 on Comma Discord

Description:
Added PID-based lateral tuning for Cherokee KL Port Fork. 
PID Parameters match other Chrysler / Jeeps for now.    Kf slightly modified.
Disabled Chrysler "High Min Steer Speed" flag, not a focus of testing.

Tested:
2019 Cherokee KL w/ Prem. Tech Pkg.  (ACC, LKAS, Park Assist)

Routes:
1. 39180e809b48857f/2024-04-02--07-31-25/13
2. 39180e809b48857f/2024-04-01--19-54-28/5

Notes:
1. PID Lateral works well, keeps center of lane.
2. No faults of any kind.

Priorities:
1.  Port accepted by upstream (OP Main)
2.  Explore steering torque limit
3.  White Panda Mod testing <39mph