### PR TITLE
Jeep Cherokee 5th Gen Car Logic within CUSW, Tuning, Tested Min_Speed, Tested Steer_Max

### DIFF
--- a/selfdrive/car/chrysler/carcontroller.py
+++ b/selfdrive/car/chrysler/carcontroller.py
@@ -62,7 +62,7 @@ class CarController(CarControllerBase):
       elif self.CP.carFingerprint in CUSW_CARS:
         # TODO: Chrysler 200 appears to support asymmetric down to mid-13s, Cherokee not verified yet, model-year variances likely
         # TODO: Consolidate with HIGHER_MIN_STEERING_SPEED cars if we can make engage consistently work at 17.5 m/s
-        if CS.out.vEgo < 16.5:
+        if CS.out.vEgo < self.CP.minSteerSpeed: # Tested JCG5 MY 2019
           lkas_control_bit = False
 
       # EPS faults if LKAS re-enables too quickly

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -46,12 +46,12 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.00006
 
     # Jeep
-    elif candidate == CAR.JEEP_CHEROKEE_5TH_GEN:
+    elif candidate == CAR.JEEP_CHEROKEE_5TH_GEN:  # JCG5 Tested
       ret.steerActuatorDelay = 0.15
       ret.lateralTuning.init('pid')
-      ret.lateralTuning.pid.kpBP, ret.lateralTuning.pid.kiBP = [[9., 20.], [9., 20.]]
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.15, 0.30], [0.03, 0.05]]
-      ret.lateralTuning.pid.kf = 0.0002
+      ret.lateralTuning.pid.kpBP, ret.lateralTuning.pid.kiBP = [[14., 26.], [14., 26.]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.065, 0.2], [0.015, 0.025]]
+      ret.lateralTuning.pid.kf = 0.000115
 
     elif candidate in (CAR.JEEP_GRAND_CHEROKEE, CAR.JEEP_GRAND_CHEROKEE_2019):
       ret.steerActuatorDelay = 0.2
@@ -75,10 +75,11 @@ class CarInterface(CarInterfaceBase):
     else:
       raise ValueError(f"Unsupported car: {candidate}")
 
-    if ret.flags & ChryslerFlags.HIGHER_MIN_STEERING_SPEED:
-      # TODO: allow these cars to steer down to 13 m/s if already engaged.
-      # TODO: Durango 2020 may be able to steer to zero once above 38 kph
-      ret.minSteerSpeed = 17.5  # m/s 17 on the way up, 13 on the way down once engaged.
+    if candidate not in (CUSW_CARS):  # Logic untested for CUSW_CARS
+      if ret.flags & ChryslerFlags.HIGHER_MIN_STEERING_SPEED:
+        # TODO: allow these cars to steer down to 13 m/s if already engaged.
+        # TODO: Durango 2020 may be able to steer to zero once above 38 kph
+        ret.minSteerSpeed = 17.5  # m/s 17 on the way up, 13 on the way down once engaged.
 
     ret.centerToFront = ret.wheelbase * 0.44
     ret.enableBsm = (0x62cc033 if candidate in CUSW_CARS else 0x2d0) in fingerprint[0]

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -50,7 +50,7 @@ class CarInterface(CarInterfaceBase):
 
     # Jeep
     elif candidate == CAR.JEEP_CHEROKEE_5TH_GEN:  # JCG5 Tested
-      ret.steerActuatorDelay = 0.15
+      ret.steerActuatorDelay = 0.1
       ret.lateralTuning.init('pid')
       ret.lateralTuning.pid.kpBP, ret.lateralTuning.pid.kiBP = [[14., 26.], [14., 26.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.065, 0.2], [0.015, 0.025]]

--- a/selfdrive/car/chrysler/interface.py
+++ b/selfdrive/car/chrysler/interface.py
@@ -50,7 +50,7 @@ class CarInterface(CarInterfaceBase):
 
     # Jeep
     elif candidate == CAR.JEEP_CHEROKEE_5TH_GEN:  # JCG5 Tested
-      ret.steerActuatorDelay = 0.1
+      ret.steerActuatorDelay = 0.125
       ret.lateralTuning.init('pid')
       ret.lateralTuning.pid.kpBP, ret.lateralTuning.pid.kiBP = [[14., 26.], [14., 26.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.065, 0.2], [0.015, 0.025]]

--- a/selfdrive/car/chrysler/values.py
+++ b/selfdrive/car/chrysler/values.py
@@ -63,9 +63,9 @@ class CAR(Platforms):
   )
 
   # Jeep
-  JEEP_CHEROKEE_5TH_GEN = ChryslerPlatformConfig(
+  JEEP_CHEROKEE_5TH_GEN = ChryslerPlatformConfig( # Tested JCG5 MY 2019
     [ChryslerCarDocs("Jeep Cherokee 2019-23")],
-    ChryslerCarSpecs(mass=1747., wheelbase=2.70, steerRatio=17.0, minSteerSpeed=18.5),
+    ChryslerCarSpecs(mass=1747., wheelbase=2.70, steerRatio=17.0, minSteerSpeed=14),
     dbc_dict('chrysler_cusw', None),
   )
   JEEP_GRAND_CHEROKEE = ChryslerPlatformConfig(  # includes 2017 Trailhawk
@@ -111,7 +111,7 @@ class CarControllerParams:
     elif CP.carFingerprint in CUSW_CARS:
       self.STEER_DELTA_UP = 4
       self.STEER_DELTA_DOWN = 4
-      self.STEER_MAX = 250  # TODO: re-validate this, Panda is at 261
+      self.STEER_MAX = 260   # Tested JCG5 MY 2019 - Upper Limit at 260
     else:
       self.STEER_DELTA_UP = 3
       self.STEER_DELTA_DOWN = 3


### PR DESCRIPTION
As Briefly discussed on the thread, this PR includes:
- Validated 14 m/s min. speed
- Validated maximum torque / Steer_max at 255, implemented in OP, Panda
- Implemented tuning settings from May 2024 testing in Discord channel.   Supported by jyoung8607 and Michael-Perillo.   Works well on highways, okay on back-roads.
- As requested, removed the commented out sections in Panda that you had temp. disabled for testing (around torque command checks).  Working without errors with torque limit at 255.
- Implemented logic in OP and Panda to maintain Chrylser CUSW as a platform and split off Cherokee 5th Gen as a car within the platform.   Allows us to differentiate steering settings, speed/tuning settings if discrepancies between model year or car within platform (Chrysler 300?).  This logic is not complete as I we are not yet passing the car as an argument into the safety config function. And we're not using the flag approach as other chryslers are using.
- Did not do anything to change addresses.   Assuming all relevant CUSW messages are common between vehicles within CUSW.  

I'm not sure if you're interested in pulling in any of this, but I was trying it out to validate the concept and better learn the approach to porting.